### PR TITLE
refine:  跳转速度优化

### DIFF
--- a/Example/TheRouter.xcodeproj/project.pbxproj
+++ b/Example/TheRouter.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1C41F0152B0DD793002E2F24 /* TheRouterControllerE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C41F0142B0DD792002E2F24 /* TheRouterControllerE.swift */; };
 		1C839B9B2AA6F67A00726596 /* TheRouterModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C839B8D2AA6F67A00726596 /* TheRouterModel.swift */; };
 		1C839B9C2AA6F67A00726596 /* TheRouterControllerC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C839B8E2AA6F67A00726596 /* TheRouterControllerC.swift */; };
 		1C839B9D2AA6F67A00726596 /* TheRouterApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C839B8F2AA6F67A00726596 /* TheRouterApi.swift */; };
@@ -20,11 +21,11 @@
 		1C839BA52AA6F67A00726596 /* TheRouterControllerD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C839B982AA6F67A00726596 /* TheRouterControllerD.swift */; };
 		1C839BA62AA6F67A00726596 /* TheRouterController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C839B992AA6F67A00726596 /* TheRouterController.swift */; };
 		1C839BA72AA6F67A00726596 /* AppConfigServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C839B9A2AA6F67A00726596 /* AppConfigServices.swift */; };
+		4394034DB0690EBF3D6B71BF /* Pods_TheRouter_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B79F8205362B05ED97B22883 /* Pods_TheRouter_Tests.framework */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 		607FACEC1AFB9204008FA782 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* Tests.swift */; };
-		B5CBFF13B1E476EF55E9A407 /* Pods_TheRouter_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5AC60C1AA12ED1D49083E331 /* Pods_TheRouter_Tests.framework */; };
-		B684D554B1ABF8A4239F60AE /* Pods_TheRouter_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1073EF712F00816E5D80D7B3 /* Pods_TheRouter_Example.framework */; };
+		B4C21EFE5B0ABE82F3498107 /* Pods_TheRouter_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD1C616AE5833A562B960C6C /* Pods_TheRouter_Example.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -39,8 +40,8 @@
 
 /* Begin PBXFileReference section */
 		09546D12C361FE0E5F02A56B /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
-		1073EF712F00816E5D80D7B3 /* Pods_TheRouter_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TheRouter_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		12FA9F3BF6BBEE9E04423D1E /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
+		1C41F0142B0DD792002E2F24 /* TheRouterControllerE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TheRouterControllerE.swift; sourceTree = "<group>"; };
 		1C839B8C2AA6F67900726596 /* TheRouter_Example-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TheRouter_Example-Bridging-Header.h"; sourceTree = "<group>"; };
 		1C839B8D2AA6F67A00726596 /* TheRouterModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TheRouterModel.swift; sourceTree = "<group>"; };
 		1C839B8E2AA6F67A00726596 /* TheRouterControllerC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TheRouterControllerC.swift; sourceTree = "<group>"; };
@@ -57,7 +58,6 @@
 		1C839B992AA6F67A00726596 /* TheRouterController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TheRouterController.swift; sourceTree = "<group>"; };
 		1C839B9A2AA6F67A00726596 /* AppConfigServices.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppConfigServices.swift; sourceTree = "<group>"; };
 		3C4F81FF1E1F872F282998C8 /* Pods-TheRouter_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TheRouter_Tests.debug.xcconfig"; path = "Target Support Files/Pods-TheRouter_Tests/Pods-TheRouter_Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		5AC60C1AA12ED1D49083E331 /* Pods_TheRouter_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TheRouter_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACD01AFB9204008FA782 /* TheRouter_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TheRouter_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACD41AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		607FACDC1AFB9204008FA782 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
@@ -66,8 +66,10 @@
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		607FACEB1AFB9204008FA782 /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
 		8A89F6440DC6CAA813B5264B /* Pods-TheRouter_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TheRouter_Example.debug.xcconfig"; path = "Target Support Files/Pods-TheRouter_Example/Pods-TheRouter_Example.debug.xcconfig"; sourceTree = "<group>"; };
-		A397706F487B5EF4A43510A6 /* TheRouter.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = TheRouter.podspec; path = ../TheRouter.podspec; sourceTree = "<group>"; };
+		A397706F487B5EF4A43510A6 /* TheRouter.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = TheRouter.podspec; path = ../TheRouter.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		A743C1781FB56171B383C18A /* Pods-TheRouter_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TheRouter_Example.release.xcconfig"; path = "Target Support Files/Pods-TheRouter_Example/Pods-TheRouter_Example.release.xcconfig"; sourceTree = "<group>"; };
+		B79F8205362B05ED97B22883 /* Pods_TheRouter_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TheRouter_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DD1C616AE5833A562B960C6C /* Pods_TheRouter_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TheRouter_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FF1C0100BC70EE123DBECCBE /* Pods-TheRouter_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TheRouter_Tests.release.xcconfig"; path = "Target Support Files/Pods-TheRouter_Tests/Pods-TheRouter_Tests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -76,7 +78,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B684D554B1ABF8A4239F60AE /* Pods_TheRouter_Example.framework in Frameworks */,
+				B4C21EFE5B0ABE82F3498107 /* Pods_TheRouter_Example.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -84,7 +86,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B5CBFF13B1E476EF55E9A407 /* Pods_TheRouter_Tests.framework in Frameworks */,
+				4394034DB0690EBF3D6B71BF /* Pods_TheRouter_Tests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -94,8 +96,8 @@
 		1369ACC45B86C5AE199F2F94 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				1073EF712F00816E5D80D7B3 /* Pods_TheRouter_Example.framework */,
-				5AC60C1AA12ED1D49083E331 /* Pods_TheRouter_Tests.framework */,
+				DD1C616AE5833A562B960C6C /* Pods_TheRouter_Example.framework */,
+				B79F8205362B05ED97B22883 /* Pods_TheRouter_Tests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -135,6 +137,7 @@
 				1C839B962AA6F67A00726596 /* TheRouterControllerB.swift */,
 				1C839B8E2AA6F67A00726596 /* TheRouterControllerC.swift */,
 				1C839B982AA6F67A00726596 /* TheRouterControllerD.swift */,
+				1C41F0142B0DD792002E2F24 /* TheRouterControllerE.swift */,
 				1C839B8D2AA6F67A00726596 /* TheRouterModel.swift */,
 				1C839B902AA6F67A00726596 /* TheRouterWebController.swift */,
 				1C839B912AA6F67A00726596 /* ViewController.swift */,
@@ -204,7 +207,7 @@
 				607FACCC1AFB9204008FA782 /* Sources */,
 				607FACCD1AFB9204008FA782 /* Frameworks */,
 				607FACCE1AFB9204008FA782 /* Resources */,
-				4EF4988B7BAE66402FDB11CB /* [CP] Embed Pods Frameworks */,
+				200822E537BC884111ECC466 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -246,10 +249,12 @@
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
+						DevelopmentTeam = CU4XLCPFAU;
 						LastSwiftMigration = 1430;
 					};
 					607FACE41AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
+						DevelopmentTeam = CU4XLCPFAU;
 						LastSwiftMigration = 0900;
 						TestTargetID = 607FACCF1AFB9204008FA782;
 					};
@@ -296,7 +301,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		4EF4988B7BAE66402FDB11CB /* [CP] Embed Pods Frameworks */ = {
+		200822E537BC884111ECC466 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -370,6 +375,7 @@
 				1C839BA72AA6F67A00726596 /* AppConfigServices.swift in Sources */,
 				1C839B9B2AA6F67A00726596 /* TheRouterModel.swift in Sources */,
 				1C839BA22AA6F67A00726596 /* AppDelegate.swift in Sources */,
+				1C41F0152B0DD793002E2F24 /* TheRouterControllerE.swift in Sources */,
 				1C839BA32AA6F67A00726596 /* TheRouterControllerB.swift in Sources */,
 				1C839BA42AA6F67A00726596 /* TheRouterBController.m in Sources */,
 				1C839B9D2AA6F67A00726596 /* TheRouterApi.swift in Sources */,
@@ -513,11 +519,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = CU4XLCPFAU;
 				INFOPLIST_FILE = TheRouter/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.sdemo.--PRODUCT-NAME-rfc1034identifier-";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "TheRouter/TheRouter_Example-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -533,11 +540,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = CU4XLCPFAU;
 				INFOPLIST_FILE = TheRouter/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.sdemo.--PRODUCT-NAME-rfc1034identifier-";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "TheRouter/TheRouter_Example-Bridging-Header.h";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
@@ -550,6 +558,7 @@
 			baseConfigurationReference = 3C4F81FF1E1F872F282998C8 /* Pods-TheRouter_Tests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				DEVELOPMENT_TEAM = CU4XLCPFAU;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -574,6 +583,7 @@
 			baseConfigurationReference = FF1C0100BC70EE123DBECCBE /* Pods-TheRouter_Tests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				DEVELOPMENT_TEAM = CU4XLCPFAU;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"$(inherited)",

--- a/Example/TheRouter/AppDelegate.swift
+++ b/Example/TheRouter/AppDelegate.swift
@@ -22,11 +22,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
 
         // 路由懒加载注册
+        TheRouterManager.loadRouterClass([".The"], useCache: true)
+        
         TheRouter.lazyRegisterRouterHandle { url, userInfo in
             TheRouterManager.injectRouterServiceConfig(webRouterUrl, serivceHost)
             return TheRouterManager.addGloableRouter([".The"], url, userInfo)
         }
-
+        
         // 动态注册服务
         TheRouterManager.registerServices()
 

--- a/Example/TheRouter/TheRouterApi.swift
+++ b/Example/TheRouter/TheRouterApi.swift
@@ -93,3 +93,12 @@ public class TheRouterWebApi: CustomRouterInfo {
     public init() {}
 }
 
+public class TheRouterEApi: CustomRouterInfo {
+    
+    public static var patternString = "scheme://router/demo9"
+    public static var routerClass = "TheRouter_Example.TheRouterControllerE"
+    public var params: [String: Any] { return [:] }
+    public var jumpType: LAJumpType = .push
+    
+    public init() {}
+}

--- a/Example/TheRouter/TheRouterControllerA.swift
+++ b/Example/TheRouter/TheRouterControllerA.swift
@@ -65,4 +65,8 @@ extension TheRouterControllerA: TheRouterable {
         vc.resultLabel.text = info.description
         return vc
     }
+    
+    static var priority: UInt {
+        TheRouterDefaultPriority
+    }
 }

--- a/Example/TheRouter/TheRouterControllerB.swift
+++ b/Example/TheRouter/TheRouterControllerB.swift
@@ -21,4 +21,8 @@ public class TheRouterControllerB: TheRouterBController, TheRouterable {
         vc.desLabel.text = info.description
         return vc
     }
+    
+    public static var priority: UInt {
+        TheRouterDefaultPriority
+    }
 }

--- a/Example/TheRouter/TheRouterControllerC.swift
+++ b/Example/TheRouter/TheRouterControllerC.swift
@@ -66,4 +66,8 @@ extension TheRouterControllerC: TheRouterable {
         vc.resultLabel.text = info.description
         return vc
     }
+    
+    static var priority: UInt {
+        TheRouterDefaultPriority
+    }
 }

--- a/Example/TheRouter/TheRouterControllerD.swift
+++ b/Example/TheRouter/TheRouterControllerD.swift
@@ -65,4 +65,8 @@ extension TheRouterControllerD: TheRouterable {
         vc.resultLabel.text = info.description
         return vc
     }
+    
+    static var priority: UInt {
+        TheRouterDefaultPriority
+    }
 }

--- a/Example/TheRouter/TheRouterControllerE.swift
+++ b/Example/TheRouter/TheRouterControllerE.swift
@@ -1,8 +1,8 @@
 //
-//  TheRouterViewController.swift
+//  TheRouterControllerE.swift
 //  TheRouter_Example
 //
-//  Created by mars.yao on 2023/3/8.
+//  Created by mars.yao on 2023/11/22.
 //  Copyright © 2023 CocoaPods. All rights reserved.
 //
 
@@ -11,14 +11,12 @@ import UIKit
 import TheRouter
 import SnapKit
 
-public typealias QrScanResultCallBack = (_ qrResult: String, _ isSucess: Bool) -> Void
-
-class TheRouterController: UIViewController {
+class TheRouterControllerE: UIViewController {
 
     // 扫码完成回调
     public var qrResultCallBack: QrScanResultCallBack?
     
-    private lazy var resultLabel: UILabel = {
+    public lazy var resultLabel: UILabel = {
         let lb = UILabel()
         lb.textColor = .black
         lb.font = UIFont.systemFont(ofSize: 15)
@@ -29,7 +27,7 @@ class TheRouterController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view.backgroundColor = .white
+        self.view.backgroundColor = .purple
         self.view.addSubview(resultLabel)
     
         resultLabel.snp.makeConstraints { make in
@@ -53,16 +51,16 @@ class TheRouterController: UIViewController {
 
 }
 
-extension TheRouterController: TheRouterable {
+extension TheRouterControllerE: TheRouterable {
     
     static var patternString: [String] {
-        ["scheme://router/demo"]
+        ["scheme://router/demo9"]
     }
     
     static func registerAction(info: [String : Any]) -> Any {
         debugPrint(info)
         
-        let vc =  TheRouterController()
+        let vc =  TheRouterControllerE()
         vc.qrResultCallBack = info["clouse"] as? QrScanResultCallBack
         vc.resultLabel.text = info.description
         return vc

--- a/Example/TheRouter/TheRouterWebController.swift
+++ b/Example/TheRouter/TheRouterWebController.swift
@@ -88,4 +88,8 @@ extension TheRouterWebController: TheRouterable {
         return webVC
     }
     
+    static var priority: UInt {
+        TheRouterDefaultPriority
+    }
+    
 }

--- a/Example/TheRouter/ViewController.swift
+++ b/Example/TheRouter/ViewController.swift
@@ -21,7 +21,8 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
                                          "注册路由是否正确的本地安全检查",
                                          "动态注册路由的性能优化部分",
                                          "OC类路由的动态注册实现",
-                                         "动态注册中KVO派生子类处理"],
+                                         "动态注册中KVO派生子类处理",
+                                         "缓存跳转"],
                                         ["无参数跳转",
                                          "有参数跳转",
                                          "多参数类型跳转",
@@ -140,6 +141,8 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
            
             let model = TheRouterModel.init(name: "AKyS", age: 18)
             TheRouter.openURL(("scheme://router/demo2?id=2&value=3&name=AKyS&desc=runtime动态注册中，会找到KVO监听派生子类标志NSKVONotifying_，但其并不是我们真正使用的工程类，需要特殊处理，通过字符截取找到真正的指向类", ["model": model]))
+        case 7:
+            TheRouter.openURL("scheme://router/demo?desc=缓存跳转")
         default:
             break
         }

--- a/Example/TheRouter/ViewController.swift
+++ b/Example/TheRouter/ViewController.swift
@@ -142,7 +142,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
             let model = TheRouterModel.init(name: "AKyS", age: 18)
             TheRouter.openURL(("scheme://router/demo2?id=2&value=3&name=AKyS&desc=runtime动态注册中，会找到KVO监听派生子类标志NSKVONotifying_，但其并不是我们真正使用的工程类，需要特殊处理，通过字符截取找到真正的指向类", ["model": model]))
         case 7:
-            TheRouter.openURL("scheme://router/demo?desc=缓存跳转")
+            TheRouter.openURL("scheme://router/demo9?desc=缓存跳转")
         default:
             break
         }

--- a/TheRouter.podspec
+++ b/TheRouter.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'TheRouter'
-  s.version          = '1.1.0'
+  s.version          = '1.1.1'
   s.summary          = 'TheRouter一个用于模块间解耦和通信，基于Swift协议进行动态懒加载注册路由与打开路由的工具。同时支持通过Service-Protocol寻找对应的模块，并用 protocol进行依赖注入和模块通信。'
 
 # This description is used to generate tags and improve search results.

--- a/TheRouter/Classes/TheRouter+Convenience.swift
+++ b/TheRouter/Classes/TheRouter+Convenience.swift
@@ -29,10 +29,10 @@ public extension TheRouter {
     /// - Parameters:
     ///   - patternString: register urlstring
     ///   - classString: the class which match the className need inherit the protocol of TheRouterable
-    class func addRouterItem(_ patternString: String, classString: String) {
+    class func addRouterItem(_ patternString: String, priority: uint = 0, classString: String) {
         let clz: AnyClass? = classString.trimmingCharacters(in: CharacterSet.whitespaces).la_matchClass()
         if let routerable = clz as? TheRouterable.Type {
-            self.addRouterItem(patternString.trimmingCharacters(in: CharacterSet.whitespaces), handle: routerable.registerAction)
+            self.addRouterItem(patternString.trimmingCharacters(in: CharacterSet.whitespaces), priority: priority, handle: routerable.registerAction)
         } else {
             shareInstance.logcat?(patternString, .logError, "\(classString) register router error， please implementation the TheRouterable Protocol")
             assert(clz as? TheRouterable.Type != nil, "register router error， please implementation the TheRouterable Protocol")

--- a/TheRouter/Classes/TheRouter+Generate.swift
+++ b/TheRouter/Classes/TheRouter+Generate.swift
@@ -9,14 +9,23 @@ import Foundation
 import UIKit
 
 // MARK: - Constants
-// 跳转类型
+// 跳转类型Key
 public let LAJumpTypeKey = "jumpType"
-// 第一个参数
+// 第一个参数Key
 public let TheRouterIvar1Key = "ivar1"
-// 第二个参数
+// 第二个参数Key
 public let TheRouterIvar2Key = "ivar2"
-// 返回值类型
+// 返回值类型Key
 public let TheRouterFunctionResultKey = "resultType"
+// 路由Path常量Key
+public let TheRouterPath = "path"
+// 路由class常量Key
+public let TheRouterClassName = "class"
+//路由priority常量Key
+public let TheRouterPriority = "priority"
+
+//路由优先级默认值
+public let TheRouterDefaultPriority: UInt = 1000
 
 public typealias ComplateHandler = (([String: Any]?, Any?) -> Void)?
 

--- a/TheRouter/Classes/TheRouter+Jump.swift
+++ b/TheRouter/Classes/TheRouter+Jump.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 // extension of viewcontroller jump for TheRouter
 extension TheRouter {

--- a/TheRouter/Classes/TheRouterDebugTool.swift
+++ b/TheRouter/Classes/TheRouterDebugTool.swift
@@ -1,0 +1,31 @@
+//
+//  TheRouterDebugTool.swift
+//  TheRouter
+//
+//  Created by mars.yao on 2023/11/22.
+//
+
+import Foundation
+import UIKit
+
+public class TheRouterDebugTool {
+    /// 检测 是否 被追踪
+    @inline(__always)
+    public static func checkTracing() -> Bool {
+        let mib = UnsafeMutablePointer<Int32>.allocate(capacity: 4)
+        mib[0] = CTL_KERN//内核查看
+        mib[1] = KERN_PROC//进程查看
+        mib[2] = KERN_PROC_PID//进程ID
+        mib[3] = getpid()//获取pid
+        var size: Int = MemoryLayout<kinfo_proc>.size
+        var info: kinfo_proc? = nil
+        /* 函数的返回值若为0时，证明没有错误，其他数字为错误码。 arg1 传入一个数组，该数组中的第一个元素指定本请求定向到内核的哪个子系统。第二个及其后元素依次细化指定该系统的某个部分。 arg2 数组中的元素数目 arg3 一个结构体，指向一个供内核存放该值的缓冲区，存放进程查询结果 arg4 缓冲区的大小 arg5/arg6 为了设置某个新值，arg5参数指向一个大小为arg6参数值的缓冲区。如果不准备指定一个新值，那么arg5应为一个空指针，arg6因为0. */
+        sysctl(mib, 4, &info, &size, nil, 0)
+        //info.kp_proc.p_flag中存放的是标志位（二进制），在proc.h文件中有p_flag的宏定义，通过&运算可知对应标志位的值是否为0。（若结果值为0则对应标志位为0）。其中P_TRACED为正在跟踪调试过程。
+        if (info.unsafelyUnwrapped.kp_proc.p_flag & P_TRACED) > 0 {
+            //监听到被调试，退出程序
+            return true
+        }
+        return false
+    }
+}

--- a/TheRouter/Classes/TheRouterable.swift
+++ b/TheRouter/Classes/TheRouterable.swift
@@ -7,9 +7,13 @@
 
 import UIKit
 
+
 public protocol TheRouterable {
     
     static var patternString: [String] { get }
         
     static func registerAction(info: [String: Any]) -> Any
+    
+    static var priority: UInt { get }
 }
+


### PR DESCRIPTION
1. 将路由懒加载中遍历获取符合注册条件的类单独抽离，开发人员可以将这段逻辑提前进行处理。
2.  增加了根据版本号缓存路由信息功能：满足仅当配置使用缓存，且取到的缓存不为空则走缓存注册逻辑。
3.  接入方可以通过配置接口来决定是否走本地缓存能力。
4. TheRouterable协议 增加了优先级参数priority，默认需要进行配置，根据业务配置不同界面的优先级。